### PR TITLE
Streaming multipart/related parsing

### DIFF
--- a/examples/python/ia_wholeslide/pyproject.toml
+++ b/examples/python/ia_wholeslide/pyproject.toml
@@ -8,7 +8,6 @@ authors = [
 requires-python = ">=3.11"
 dependencies = [
     "flask>=3.0.3",
-    "requests-toolbelt>=1.0.0",
     "requests>=2.32.3",
     "tqdm>=4.67.0",
     "pillow>=11.0.0",

--- a/examples/python/ia_wholeslide/src/dpat_wholeslide/multipart.py
+++ b/examples/python/ia_wholeslide/src/dpat_wholeslide/multipart.py
@@ -1,0 +1,190 @@
+import logging
+from typing import Iterable, Iterator, Tuple
+
+
+class MultipartParser:
+    """Parser for multipart/related response message.
+
+    Requires (but does not check):
+        - Chunk size must be equal or larger than the boundary length.
+        - Parts are files with a filename in the header.
+    """
+
+    HEADER_DELIMITER = b"\r\n\r\n"
+    END_DELIMITER = b"--\r\n"
+    END_DELIMITER_LENGTH = len(END_DELIMITER)
+
+    def __init__(self, chunks: Iterator[bytes], boundary: str):
+        """Initialize the MultipartParser with the given chunks and boundary.
+
+        Parameters
+        ----------
+        chunks : Iterator[bytes]
+            Iterator of byte chunks from the response stream.
+        boundary : str
+            Boundary string used to separate parts in the multipart response.
+        """
+        self._chunks = chunks
+        self._start_boundary = f"--{boundary}".encode("utf-8")
+        self._boundary = "\r\n".encode("utf-8") + self._start_boundary
+        self._boundary_length = len(self._boundary)
+
+    def parts(self) -> Iterable[Tuple[str, Iterable[bytes]]]:
+        """Parse the multipart response and yield parts with their filenames and chunks."""
+        self._buffer = self._read_first_boundary_start()
+        end_of_stream = self._check_for_end_of_stream()
+        part_index = 0
+        while not end_of_stream:
+            filename = self._parse_part_header()
+            logging.debug(f"Parsing part {part_index} with filename {filename}")
+            chunks = self._parse_part_chunks()
+            yield filename, chunks
+            end_of_stream = self._check_for_end_of_stream()
+            part_index += 1
+
+    def _read_first_boundary_start(self) -> bytes:
+        """Read the first chunk from stream and return the part after the boundary
+        delimiter.
+
+        Raises RuntimeError if the first chunk does not start with the boundary.
+
+        Returns
+        -------
+        bytes
+            Part of first chunk after boundary delimiter.
+        """
+        chunk = self._read_next_chunk_from_stream()
+        if not chunk.startswith(self._start_boundary):
+            raise RuntimeError(
+                f"First chunk does not start with boundary {self._boundary}"
+            )
+        return chunk[self._boundary_length :]
+
+    def _check_for_end_of_stream(self) -> bool:
+        """Check if the end delimiter is in the buffer and if the stream has ended.
+
+        Expect that a boundary has just been read from straem. Raises RuntimeError if
+        end delimiter found but not end of stream.
+
+        Stores any data for the next part in buffer.
+
+        Returns
+        -------
+        bool
+            True if end of stream.
+        """
+        if len(self._buffer) < self.END_DELIMITER_LENGTH:
+            next_chunk = self._read_next_chunk_from_stream()
+            self._buffer += next_chunk
+        if self._buffer.startswith(self.END_DELIMITER):
+            if (
+                len(self._buffer) != self.END_DELIMITER_LENGTH
+                or next(self._chunks, None) is not None
+            ):
+                # End delimiter found, but not the end of stream
+                raise RuntimeError(
+                    "End delimiter found, but the stream did not terminate as expected"
+                )
+            return True
+        return False
+
+    def _parse_part_header(self) -> str:
+        """Parse the part header from the stream and return the filename of the part.
+
+        Stores any data for the next part in buffer.
+        Expects that the buffer is after the boundary delimiter.
+
+        Returns
+        -------
+        str
+            Filename of the part.
+        """
+        header_end_index = self._buffer.find(self.HEADER_DELIMITER)
+        while header_end_index == -1:
+            next_chunk = self._read_next_chunk_from_stream()
+            self._buffer += next_chunk
+            header_end_index = self._buffer.find(self.HEADER_DELIMITER)
+        header = self._buffer[:header_end_index].decode("utf-8")
+        # Set the buffer to the remaining data after the header
+        self._buffer = self._buffer[header_end_index + len(self.HEADER_DELIMITER) :]
+        return self._parse_filename_from_header(header)
+
+    def _parse_filename_from_header(self, header: str) -> str:
+        """Parse the filename from the header.
+
+        Parameters
+        ----------
+        header : str
+            Header string to parse.
+
+        Returns
+        -------
+        str
+            Filename extracted from the header.
+        """
+        for line in header.split("\r\n"):
+            if line.lower().startswith("content-disposition"):
+                _, *params = line.split(";")
+                for param in params:
+                    key, _, value = param.strip().partition("=")
+                    if key.lower() == "filename":
+                        filename = value.strip('"')
+                        return filename
+
+        raise ValueError("Filename not found in header")
+
+    def _parse_part_chunks(self) -> Iterator[bytes]:
+        """Read chunks from stream until boundary delimiter.
+
+        Stores any data for the next part in buffer.
+
+        Returns
+        -------
+        Iterator[bytes]
+            Chunks of the part.
+        """
+        # Check if given chunk contains the Boundary
+        end_index = self._buffer.find(self._boundary)
+        while end_index == -1:
+            # Boundary not found, read in next chunk
+            next_chunk = self._read_next_chunk_from_stream()
+            # Check if boundary between chunks. Need at most boundary length - 1 from
+            # each chunk.
+            first_chunk_boundary = self._buffer[-self._boundary_length + 1 :]
+            second_chunk_boundary = next_chunk[: self._boundary_length - 1]
+            chunk_boundary = first_chunk_boundary + second_chunk_boundary
+            end_index_in_chunk_boundary = chunk_boundary.find(self._boundary)
+            if end_index_in_chunk_boundary > 0:
+                logging.debug("Boundary found between chunks")
+                # Boundary found between chunks
+                # Yield the buffer up to the Boundary
+                yield self._buffer[
+                    : -self._boundary_length + 1 + end_index_in_chunk_boundary
+                ]
+                # Set the buffer to the remaining data
+                self._buffer = next_chunk[
+                    : self._boundary_length - 1 + end_index_in_chunk_boundary
+                ]
+                return
+            # Boundary not in between chunks, so yield the buffer and continue
+            yield self._buffer
+            self._buffer = next_chunk
+            end_index = self._buffer.find(self._boundary)
+
+        # Boundary found in the chunk, yield the chunk up to the boundary
+        yield self._buffer[:end_index]
+        # Set the buffer to the remaining data after the boundary
+        self._buffer = self._buffer[end_index + self._boundary_length :]
+
+    def _read_next_chunk_from_stream(self) -> bytes:
+        """Read the next chunk from the stream.
+
+        Returns
+        -------
+        bytes
+            Next chunk from the stream.
+        """
+        try:
+            return next(self._chunks)
+        except StopIteration:
+            raise RuntimeError("End of stream reached")

--- a/examples/python/ia_wholeslide/src/dpat_wholeslide/multipart.py
+++ b/examples/python/ia_wholeslide/src/dpat_wholeslide/multipart.py
@@ -143,38 +143,22 @@ class MultipartParser:
         Iterator[bytes]
             Chunks of the part.
         """
-        # Check if given chunk contains the Boundary
-        end_index = self._buffer.find(self._boundary)
-        while end_index == -1:
-            # Boundary not found, read in next chunk
-            next_chunk = self._read_next_chunk_from_stream()
-            # Check if boundary between chunks. Need at most boundary length - 1 from
-            # each chunk.
-            first_chunk_boundary = self._buffer[-self._boundary_length + 1 :]
-            second_chunk_boundary = next_chunk[: self._boundary_length - 1]
-            chunk_boundary = first_chunk_boundary + second_chunk_boundary
-            end_index_in_chunk_boundary = chunk_boundary.find(self._boundary)
-            if end_index_in_chunk_boundary > 0:
-                logging.debug("Boundary found between chunks")
-                # Boundary found between chunks
-                # Yield the buffer up to the Boundary
-                yield self._buffer[
-                    : -self._boundary_length + 1 + end_index_in_chunk_boundary
-                ]
-                # Set the buffer to the remaining data
-                self._buffer = next_chunk[
-                    : self._boundary_length - 1 + end_index_in_chunk_boundary
-                ]
-                return
-            # Boundary not in between chunks, so yield the buffer and continue
-            yield self._buffer
-            self._buffer = next_chunk
+        while True:
             end_index = self._buffer.find(self._boundary)
-
-        # Boundary found in the chunk, yield the chunk up to the boundary
-        yield self._buffer[:end_index]
-        # Set the buffer to the remaining data after the boundary
-        self._buffer = self._buffer[end_index + self._boundary_length :]
+            if end_index != -1:
+                # Boundary found, yield the content up to the boundary and keep
+                # the remainder (after the boundary) for the next part.
+                yield self._buffer[:end_index]
+                self._buffer = self._buffer[end_index + self._boundary_length :]
+                return
+            # Boundary not in buffer. Its first bytes may sit at the end of the
+            # buffer and complete in the next chunk, so retain the last
+            # (boundary_length - 1) bytes and yield everything before them.
+            if len(self._buffer) >= self._boundary_length:
+                flushable_length = len(self._buffer) - self._boundary_length + 1
+                yield self._buffer[:flushable_length]
+                self._buffer = self._buffer[flushable_length:]
+            self._buffer += self._read_next_chunk_from_stream()
 
     def _read_next_chunk_from_stream(self) -> bytes:
         """Read the next chunk from the stream.

--- a/examples/python/ia_wholeslide/src/dpat_wholeslide/worker.py
+++ b/examples/python/ia_wholeslide/src/dpat_wholeslide/worker.py
@@ -222,7 +222,8 @@ def download_wsi(folder):
         )
         parser = MultipartParser(r.iter_content(1024 * 1024), boundary)
         for filename, file_chunks in parser.parts():
-            dest_path = folder_path / f"wsi_files/{filename}"
+            # Only trust the filename component to avoid writing outside wsi_files.
+            dest_path = folder_path / "wsi_files" / Path(filename).name
             if not dest_path.exists():
                 dest_path.parent.mkdir(exist_ok=True, parents=True)
                 with open(dest_path, "wb") as f:

--- a/examples/python/ia_wholeslide/src/dpat_wholeslide/worker.py
+++ b/examples/python/ia_wholeslide/src/dpat_wholeslide/worker.py
@@ -231,6 +231,8 @@ def download_wsi(folder):
                         f.write(chunk)
                 print(f"wsi saved to '{dest_path}'")
             else:
+                for _ in file_chunks:
+                    pass
                 print(f"file already existed, ignored: '{dest_path}'")
     else:
         # application/octet-stream -- single file

--- a/examples/python/ia_wholeslide/uv.lock
+++ b/examples/python/ia_wholeslide/uv.lock
@@ -238,7 +238,6 @@ dependencies = [
     { name = "flask" },
     { name = "pillow" },
     { name = "requests" },
-    { name = "requests-toolbelt" },
     { name = "tqdm" },
 ]
 
@@ -253,7 +252,6 @@ requires-dist = [
     { name = "flask", specifier = ">=3.0.3" },
     { name = "pillow", specifier = ">=11.0.0" },
     { name = "requests", specifier = ">=2.32.3" },
-    { name = "requests-toolbelt", specifier = ">=1.0.0" },
     { name = "tqdm", specifier = ">=4.67.0" },
 ]
 
@@ -740,18 +738,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/63/70/2bf7780ad2d390a8d301ad0b550f1581eadbd9a20f896afe06353c2a2913/requests-2.32.3.tar.gz", hash = "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760", size = 131218 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl", hash = "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6", size = 64928 },
-]
-
-[[package]]
-name = "requests-toolbelt"
-version = "1.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6", size = 206888 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl", hash = "sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06", size = 54481 },
 ]
 
 [[package]]


### PR DESCRIPTION
Replace multipart-parser from requests-toolbelt with simple streaming parser.

Tested using ./src/dpat_wholeslide/worker.py process on a DICOM slide.